### PR TITLE
Remove contact form from Contact page (#20)

### DIFF
--- a/src/component/page/PageContact.jsx
+++ b/src/component/page/PageContact.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "./PageContact.css";
 import BoxWithTitle from "../box/BoxWithTitle.jsx";
-import SectionContactForm from "../section/SectionContactForm.jsx";
 
 export default class PageContact extends React.Component {
 	constructor(props) {
@@ -15,7 +14,6 @@ export default class PageContact extends React.Component {
 	render() {
 		return (
 			<div id="PageContact">
-				<SectionContactForm/>
 
 				<div className="max-sized-section">
 					<div className="row">


### PR DESCRIPTION
This PR removes the contact form from the Contact page, leaving only the three cards for email, phone, and physical address.

Fixes #20