### PR TITLE
Merge bugfix/23--broken-launchpad-link into validation

### DIFF
--- a/src/component/page/pagesupportforstartups/PageSupportForStartupsLaunchpadLux.css
+++ b/src/component/page/pagesupportforstartups/PageSupportForStartupsLaunchpadLux.css
@@ -1,6 +1,6 @@
 
 #PageSupportForStartupsLaunchpadLux {
-	padding: 40px 0px;
+	padding: 40px 0;
 }
 
 #PageSupportForStartupsLaunchpadLux .title {
@@ -14,4 +14,26 @@
 #PageSupportForStartupsLaunchpadLux .box i {
 	font-size: 42px;
 	color: var(--primary-blue-80);
+}
+
+.card-link {
+  all: unset;
+  display: block;
+  cursor: pointer;
+  outline: revert;
+  outline-offset: revert;
+}
+
+.card-link:hover {
+  color: inherit;
+}
+
+.card-link:focus-visible {
+  outline: 2px solid #000;
+  border-radius: 12px;
+  outline-offset: -2px;
+}
+
+.card-link:focus:not(:focus-visible) {
+  outline: none;
 }

--- a/src/component/page/pagesupportforstartups/PageSupportForStartupsLaunchpadLux.jsx
+++ b/src/component/page/pagesupportforstartups/PageSupportForStartupsLaunchpadLux.jsx
@@ -8,57 +8,67 @@ export default class PageSupportForStartupsLaunchpadLux extends React.Component 
 			<div id="PageSupportForStartupsLaunchpadLux">
 				<div className="row spaced-row">
 					<div className="col-md-4 offset-md-2">
-						<div className="box vertically-centered centered">
-							<div className="row">
-								<div className="col-md-6 offset-md-3 spaced-row">
-									<i className="fas fa-mountain"/>
-								</div>
+						<a
+							aria-label={"Go to: \"Startup Luxembourg\""}
+							href={"https://www.startupluxembourg.com/why-luxembourg/at-a-glance"}
+							target="_blank"
+							rel="noreferrer"
+							className="card-link"
+						>
+							<div className="box vertically-centered centered ">
+								<div className="row">
+									<div className="col-md-6 offset-md-3 spaced-row">
+										<i className="fas fa-mountain"/>
+									</div>
 
-								<div className="col-md-8 offset-md-2">
-									<div className="h8 spaced-row">
-										A thriving startups community
+									<div className="col-md-8 offset-md-2">
+										<div className="h8 spaced-row">
+									A thriving startups community
+										</div>
+									</div>
+
+									<div className="col-md-12 text-primary" style={{ textDecoration: "underline" }}>
+									Startup Luxembourg
+										<i
+											className="fa fa-up-right-from-square"
+											style={{ fontSize: "1em", marginLeft: "0.5em", color: "inherit" }}
+										/>
 									</div>
 								</div>
-
-								<div className="col-md-12">
-									<button
-										className="small"
-										onClick={() => window.open(
-											"https://www.startupluxembourg.com/why-luxembourg/at-a-glance",
-											"_blank",
-										)}>
-										Startup Luxembourg
-									</button>
-								</div>
 							</div>
-						</div>
+						</a>
 					</div>
 
 					<div className="col-md-4">
-						<div className="box vertically-centered centered">
-							<div className="row">
-								<div className="col-md-6 offset-md-3 spaced-row">
-									<i className="fas fa-tasks"/>
-								</div>
+						<a
+							aria-label={"Go to: \"Luxembourg Trade and Invest\""}
+							href={"https://luxembourgtradeandinvest.com/choose-luxembourg/explore-luxembourg-as-your-next-business-destination"}
+							target="_blank"
+							rel="noreferrer"
+							className="card-link"
+						>
+							<div className="box vertically-centered centered">
+								<div className="row">
+									<div className="col-md-6 offset-md-3 spaced-row">
+										<i className="fas fa-tasks"/>
+									</div>
 
-								<div className="col-md-8 offset-md-2">
-									<div className="h8 spaced-row">
-										10 good reasons to choose Luxembourg
+									<div className="col-md-8 offset-md-2">
+										<div className="h8 spaced-row">
+									10 good reasons to choose Luxembourg
+										</div>
+									</div>
+
+									<div className="col-md-12 text-primary" style={{ textDecoration: "underline" }}>
+										Luxembourg Trade and Invest
+										<i
+											className="fa fa-up-right-from-square"
+											style={{ fontSize: "1em", marginLeft: "0.5em", color: "inherit" }}
+										/>
 									</div>
 								</div>
-
-								<div className="col-md-12">
-									<button
-										className="small"
-										onClick={() => window.open(
-											"https://www.luxinnovation.lu/wp-content/uploads/sites/3/2022/10/10-good-reasons-july-2022-web-en-ti.pdf",
-											"_blank",
-										)}>
-										Download the brochure
-									</button>
-								</div>
 							</div>
-						</div>
+						</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Closes issue #23 

- Fix broken link (404) for "10 reasons to Luxembourg" button
- Make the card the link (UX)
- Replace with correct link element (accessibility)
- Fix link visibility (accessibility)
- Fix keyboard focus outline (accessibility)

<img width="648" height="217" alt="image" src="https://github.com/user-attachments/assets/77e68f2f-5deb-4614-9326-34eda9757cb1" />

